### PR TITLE
added input parameters for thumbnail and primary image urls

### DIFF
--- a/.github/workflows/build-release-upload-ci.yml
+++ b/.github/workflows/build-release-upload-ci.yml
@@ -10,6 +10,12 @@ on:
       control-description:
         description: Control description
         type: string
+      control-thumbnail-url:
+        description: Cotnrol thumbnail url
+        type: string
+      control-primary-image-url:
+        description: Cotnrol primary image url
+        type: string
       control-youtube-video-url:
         description: Cotnrol youtube video url
         type: string
@@ -162,6 +168,8 @@ jobs:
           version: v${{ steps.get-solution-data.outputs.version }}
           blobPath: ${{ steps.get-solution-data.outputs.unique-name }}/${{ steps.get-solution-data.outputs.unique-name }}_${{ steps.get-solution-data.outputs.parsed-version }}_managed.zip
           gitRepoUrl: https://github.com/BeverCRM/PCF-${{ steps.get-solution-data.outputs.unique-name }}
+          thumbnailUrl: ${{ inputs.control-thumbnail-url }}
+          primaryImageUrl: ${{ inputs.control-primary-image-url }}
           youtubeVideoUrl: ${{ inputs.control-youtube-video-url }}
           price: ${{ inputs.control-price }}
           imgExtension: ${{ inputs.control-img-extension }}

--- a/README.md
+++ b/README.md
@@ -38,6 +38,22 @@ Create a workflow ```.yml``` file in your ```.github/workflows``` directory. An 
     <td>Control description</td>
   </tr>
   <tr>
+    <td>control-thumbnail-url</td>
+    <td>Optional</td>
+    <td>string</td>
+    <td>---</td>
+    <td>---</td>
+    <td>Control thumbnail url</td>
+  </tr>
+  <tr>
+    <td>control-primary-image-url</td>
+    <td>Optional</td>
+    <td>string</td>
+    <td>---</td>
+    <td>---</td>
+    <td>Control primary image url</td>
+  </tr>
+  <tr>
     <td>control-youtube-video-url</td>
     <td>Optional</td>
     <td>string</td>
@@ -218,6 +234,8 @@ jobs:
     with:
       control-title: Sample Custom Component # required
       # control-description: '' # default
+      # control-thumbnail-url: '' # default
+      # control-primary-image-url: '' # default
       # control-youtube-video-url: '' # default
       # control-price: Free # default
       # control-img-extension: png # default


### PR DESCRIPTION
thumbnail-url :: github small image url (one of the images from README.md) that is used as a thumbnail on the PCF Controls page
primary-image-url :: github large image url (one of the images from README.md) that is used as a primary image on the specific PCF page if the youtube-url is not ready yet