### PR TITLE
added refreshTypes npm command

### DIFF
--- a/.github/workflows/build-release-upload-update-rw.yml
+++ b/.github/workflows/build-release-upload-update-rw.yml
@@ -318,6 +318,10 @@ jobs:
         id: install-dependecies
         run: npm ci
 
+      - name: Refresh types (create generated/ManifestTypes.d.ts)
+        id: refresh-types
+        run: npm run refreshTypes
+
       - name: Setup MSBuild
         uses: microsoft/setup-msbuild@v1
 


### PR DESCRIPTION
added refreshTypes npm command in order to avoid pac-scripts module version issue
some versions automatically generate ManifestTypes.d.ts, but e.g. **v1.20.3**  does not